### PR TITLE
fix: 修復 `tsconfig` 編譯路徑問題

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,12 +4,9 @@
         "noImplicitAny": true,
         "sourceMap": true,
         "outDir": "dist",
-        "baseUrl": ".",
-        "paths": {
-            "*": ["node_modules/*"]
-        }
+        "rootDir": "src"
     },
     "include": [
         "src/**/*"
-, "__test__/RecentlyEditedController.test.ts"    ]
+    ]
 }


### PR DESCRIPTION
## Fix
- 修復 `tsconfig` 當中關於編譯設定的錯誤

> [!IMPORTANT]
> * 應用新環境後，如果有使用過舊環境編譯，請 **刪除整個`dist`資料夾** 後，重新編譯(`npm start`&`npm build`)
> * `__test__` 目錄下的內容不需要被編譯，它只會在測試時生效(`npm test`&`npm test-watch`)

有其他問題再麻煩告知